### PR TITLE
Refactor cache service initialization and add support for custom name…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,6 @@ jobs:
                   node-version: '18'
                   registry-url: 'https://registry.npmjs.org/'
 
-            - name: Set up Docker
-              uses: docker/setup-buildx-action@v2
-              # run: sudo apt-get update && sudo apt-get install docker.io -y
-
-            - name: Start RabbitMQ
-              run: docker run -d -p 5672:5672 -p 15672:15672 --name rabbitmq rabbitmq:3-management
-
             - name: Install Dependencies
               run: npm install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
     "name": "ck-ms-cache",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ck-ms-cache",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
-                "ck-ms-di": "^2.0.2"
+                "ck-ms-di": "^2.0.2",
+                "keyv": "^5.1.0"
             },
             "devDependencies": {
                 "@types/amqplib": "^0.10.5",
                 "@types/jest": "^29.5.13",
+                "@types/keyv": "^4.2.0",
                 "@types/node": "^22.7.4",
                 "eslint": "^9.11.1",
                 "eslint-config-prettier": "^9.1.0",
@@ -1215,6 +1217,14 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@keyv/serialize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.1.tgz",
+            "integrity": "sha512-kKXeynfORDGPUEEl2PvTExM2zs+IldC6ZD8jPcfvI351MDNtfMlw9V9s4XZXuJNDK2qR5gbEKxRyoYx3quHUVQ==",
+            "dependencies": {
+                "buffer": "^6.0.3"
+            }
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1367,6 +1377,16 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
+        },
+        "node_modules/@types/keyv": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-4.2.0.tgz",
+            "integrity": "sha512-xoBtGl5R9jeKUhc8ZqeYaRDx04qqJ10yhhXYGmJ4Jr8qKpvMsDQQrNUvF/wUJ4klOtmJeJM+p2Xo3zp9uaC3tw==",
+            "deprecated": "This is a stub types definition. keyv provides its own type definitions, so you do not need this installed.",
+            "dev": true,
+            "dependencies": {
+                "keyv": "*"
+            }
         },
         "node_modules/@types/node": {
             "version": "22.7.6",
@@ -1645,6 +1665,25 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1730,6 +1769,29 @@
             "dev": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
             }
         },
         "node_modules/buffer-from": {
@@ -2449,6 +2511,15 @@
                 "node": ">=16"
             }
         },
+        "node_modules/flat-cache/node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
         "node_modules/flatted": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
@@ -2609,6 +2680,25 @@
             "engines": {
                 "node": ">=10.17.0"
             }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/ignore": {
             "version": "5.3.2",
@@ -3523,12 +3613,11 @@
             }
         },
         "node_modules/keyv": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "dev": true,
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.1.0.tgz",
+            "integrity": "sha512-FUr1fbKVsj9IZkPkY9reJ80Lp2B3ldtFXH+xK0wvZYzOpwgHV1er3xP4JUhu2cgkV2X3BJQw+hzAbIGqa+hNIA==",
             "dependencies": {
-                "json-buffer": "3.0.1"
+                "@keyv/serialize": "*"
             }
         },
         "node_modules/kleur": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ck-ms-cache",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "Used by CK-MS packages and for managing cache operations in microservice applications developed using this infrastructure.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -26,6 +26,7 @@
     "devDependencies": {
         "@types/amqplib": "^0.10.5",
         "@types/jest": "^29.5.13",
+        "@types/keyv": "^4.2.0",
         "@types/node": "^22.7.4",
         "eslint": "^9.11.1",
         "eslint-config-prettier": "^9.1.0",
@@ -38,7 +39,8 @@
         "typescript": "^5.6.2"
     },
     "dependencies": {
-        "ck-ms-di": "^2.0.2"
+        "ck-ms-di": "^2.0.2",
+        "keyv": "^5.1.0"
     },
     "repository": {
         "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,83 @@
+import { Service } from 'ck-ms-di';
+import { Keyv, KeyvOptions } from 'keyv';
+
+@Service({ lifecycle: 'singleton' })
+export class CacheService {
+    private _namespaces: Map<string, Keyv> = new Map<string, Keyv>();
+
+    public async init() {
+        this._createDevaultNamespace();
+    }
+
+    private _createDevaultNamespace() {
+        const keyv = new Keyv();
+        this._namespaces.set('default', keyv);
+    }
+
+    public createNamespace(namespace: string, options?: KeyvOptions) {
+        if (this._namespaces.has(namespace)) {
+            throw new Error(`Namespace ${namespace} already exists`);
+        }
+
+        const keyv = new Keyv(options);
+        this._namespaces.set(namespace, keyv);
+    }
+
+    public hasNamespace(namespace: string) {
+        return this._namespaces.has(namespace);
+    }
+
+    public on(namespace: string, event: string, listener: (...args: any[]) => void) {
+        if (!this._namespaces.has(namespace)) {
+            throw new Error(`Namespace ${namespace} does not exist`);
+        }
+
+        this._namespaces.get(namespace)?.on(event, listener);
+    }
+
+    public async set(namespace: string, key: string, value: any, ttl?: number) {
+        if (!this._namespaces.has(namespace)) {
+            throw new Error(`Namespace ${namespace} does not exist`);
+        }
+
+        return this._namespaces.get(namespace)?.set(key, value, ttl);
+    }
+
+    public async get(namespace: string, key: string) {
+        if (!this._namespaces.has(namespace)) {
+            throw new Error(`Namespace ${namespace} does not exist`);
+        }
+
+        return this._namespaces.get(namespace)?.get(key);
+    }
+
+    public async delete(namespace: string, key: string) {
+        if (!this._namespaces.has(namespace)) {
+            throw new Error(`Namespace ${namespace} does not exist`);
+        }
+
+        return this._namespaces.get(namespace)?.delete(key);
+    }
+
+    public async clear(namespace: string) {
+        if (!this._namespaces.has(namespace)) {
+            throw new Error(`Namespace ${namespace} does not exist`);
+        }
+
+        return this._namespaces.get(namespace)?.clear();
+    }
+
+    public async clearAll() {
+        for (const keyv of this._namespaces.values()) {
+            await keyv.clear();
+        }
+    }
+
+    public emitEvent(namespace: string, event: string) {
+        if (!this._namespaces.has(namespace)) {
+            throw new Error(`Namespace ${namespace} does not exist`);
+        }
+
+        this._namespaces.get(namespace)?.emit(event);
+    }
+}

--- a/tests/CacheService.test.ts
+++ b/tests/CacheService.test.ts
@@ -1,0 +1,127 @@
+import { CacheService } from '../src/index';
+
+describe('CacheService', () => {
+    describe('Without service container', () => {
+        it('should create a default namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            expect(cacheService.hasNamespace('default')).toBeTruthy();
+        });
+
+        it('should create a custom namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            cacheService.createNamespace('custom');
+            expect(cacheService.hasNamespace('custom')).toBeTruthy();
+        });
+
+        it('should throw an error when creating an existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            cacheService.createNamespace('custom');
+            expect(() => cacheService.createNamespace('custom')).toThrowError();
+        });
+
+        it('should throw an error when getting a non-existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await expect(cacheService.get('non-existing', 'key')).rejects.toThrow('Namespace non-existing does not exist');
+        });
+
+        it('should throw an error when setting a key in a non-existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await expect(cacheService.set('non-existing', 'key', 'value')).rejects.toThrow('Namespace non-existing does not exist');
+        });
+
+        it('should throw an error when getting a key in a non-existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await expect(cacheService.get('non-existing', 'key')).rejects.toThrow('Namespace non-existing does not exist');
+        });
+
+        it('should throw an error when deleting a key in a non-existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await expect(cacheService.delete('non-existing', 'key')).rejects.toThrow('Namespace non-existing does not exist');
+        });
+
+        it('should throw an error when clearing a non-existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await expect(cacheService.clear('non-existing')).rejects.toThrow('Namespace non-existing does not exist');
+        });
+
+        it('should set and get a key in the default namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await cacheService.set('default', 'key', 'value');
+            expect(await cacheService.get('default', 'key')).toBe('value');
+        });
+
+        it('should set and get a key in a custom namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            cacheService.createNamespace('custom');
+            await cacheService.set('custom', 'key', 'value');
+            expect(await cacheService.get('custom', 'key')).toBe('value');
+        });
+
+        it('should delete a key in the default namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await cacheService.set('default', 'key', 'value');
+            await cacheService.delete('default', 'key');
+            expect(await cacheService.get('default', 'key')).toBeUndefined();
+        });
+
+        it('should delete a key in a custom namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            cacheService.createNamespace('custom');
+            await cacheService.set('custom', 'key', 'value');
+            await cacheService.delete('custom', 'key');
+            expect(await cacheService.get('custom', 'key')).toBeUndefined();
+        });
+
+        it('should clear the default namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            await cacheService.set('default', 'key', 'value');
+            await cacheService.clear('default');
+            expect(await cacheService.get('default', 'key')).toBeUndefined();
+        });
+
+        it('should clear a custom namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            cacheService.createNamespace('custom');
+            await cacheService.set('custom', 'key', 'value');
+            await cacheService.clear('custom');
+            expect(await cacheService.get('custom', 'key')).toBeUndefined();
+        });
+
+        it('should listen to an event in a namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            cacheService.createNamespace('custom');
+            const listener = jest.fn();
+            cacheService.on('custom', 'event', listener);
+            cacheService.emitEvent('custom', 'event');
+            expect(listener).toHaveBeenCalled();
+        });
+
+        it('should throw an error when listening to an event in a non-existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            const listener = jest.fn();
+            expect(() => cacheService.on('non-existing', 'event', listener)).toThrow('Namespace non-existing does not exist');
+        });
+
+        it('should throw an error when emitting an event in a non-existing namespace', async () => {
+            const cacheService = new CacheService();
+            await cacheService.init();
+            expect(() => cacheService.emitEvent('non-existing', 'event')).toThrow('Namespace non-existing does not exist');
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces a new `CacheService` class for managing cache operations, updates dependencies, and removes unnecessary Docker setup steps in the GitHub workflow. The most important changes include the addition of the `CacheService` class, comprehensive tests for the new service, and updates to the `package.json` file.

### New Feature: Cache Service
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1-R83): Added `CacheService` class for managing cache operations with namespaces using the `keyv` library. (`[src/index.tsR1-R83](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1-R83)`)

### Testing
* [`tests/CacheService.test.ts`](diffhunk://#diff-bad8b9cdc45f51412975c3336ccfb5965fa2866a4861b5c1f9d59cfbee11c00eR1-R127): Added tests for the `CacheService` class to ensure proper functionality, including namespace creation, key-value operations, and event handling. (`[tests/CacheService.test.tsR1-R127](diffhunk://#diff-bad8b9cdc45f51412975c3336ccfb5965fa2866a4861b5c1f9d59cfbee11c00eR1-R127)`)

### Dependency Updates
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version to `1.0.0`, added `keyv` and `@types/keyv` as dependencies, and updated existing dependencies. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`, `[[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29)`, `[[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L41-R43)`)

### Workflow Simplification
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L24-L30): Removed Docker setup and RabbitMQ start steps to simplify the workflow. (`[.github/workflows/publish.ymlL24-L30](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L24-L30)`)